### PR TITLE
Grade passback fix

### DIFF
--- a/app/models/inst_module_section.rb
+++ b/app/models/inst_module_section.rb
@@ -17,6 +17,8 @@
 #  fk_rails_ff11275e48  (inst_module_version_id)
 #
 class InstModuleSection < ApplicationRecord
+  # a section in a stand-alone module
+
   belongs_to :inst_module_version
   has_many :inst_module_section_exercises, dependent: :destroy
 
@@ -54,7 +56,7 @@ class InstModuleSection < ApplicationRecord
     self.inst_module_section_exercises.each do |imse|
       imse.clone(inst_module_version, ims)
     end
-    
+
     return ims
   end
 

--- a/app/models/inst_module_section.rb
+++ b/app/models/inst_module_section.rb
@@ -16,7 +16,6 @@
 #
 #  fk_rails_ff11275e48  (inst_module_version_id)
 #
-# a section in a stand-alone module
 class InstModuleSection < ApplicationRecord
   belongs_to :inst_module_version
   has_many :inst_module_section_exercises, dependent: :destroy

--- a/app/models/inst_module_section_exercise.rb
+++ b/app/models/inst_module_section_exercise.rb
@@ -21,7 +21,6 @@
 #  fk_rails_9b61737c9f  (inst_exercise_id)
 #  fk_rails_b320810099  (inst_module_section_id)
 #
-# an \exercise in a stand-alone module
 class InstModuleSectionExercise < ApplicationRecord
 
   belongs_to :inst_module_version, inverse_of: :inst_module_section_exercises

--- a/app/models/inst_module_section_exercise.rb
+++ b/app/models/inst_module_section_exercise.rb
@@ -22,6 +22,7 @@
 #  fk_rails_b320810099  (inst_module_section_id)
 #
 class InstModuleSectionExercise < ApplicationRecord
+  # an exercise in a stand-alone module
 
   belongs_to :inst_module_version, inverse_of: :inst_module_section_exercises
   belongs_to :inst_module_section, inverse_of: :inst_module_section_exercises
@@ -91,10 +92,10 @@ class InstModuleSectionExercise < ApplicationRecord
   def self.handle_grade_passback(req, _res, user_id, inst_module_section_exercise_id)
     ex_progress = OdsaExerciseProgress.find_by(user_id: user_id,
                                                inst_module_section_exercise_id: inst_module_section_exercise_id)
-                                               
+
     if req.replace_request?
       # set a new score for the user
-            
+
       score = Float(req.score.to_s)
 
       if score < 0.0 || score > 1.0
@@ -127,7 +128,7 @@ class InstModuleSectionExercise < ApplicationRecord
       res.score = ex_progress.blank? ? 0 : ex_progress.highest_score
       res.code_major = 'success'
     end
-    
+
     return res
   end
 

--- a/app/models/inst_module_version.rb
+++ b/app/models/inst_module_version.rb
@@ -21,7 +21,6 @@
 #  fk_rails_7e343b3134                            (inst_module_id)
 #  index_inst_module_versions_on_course_resource  (course_offering_id,resource_link_id) UNIQUE
 #
-# a stand-alone module (i.e. not contained in a book) that is tied directly to a course offering
 class InstModuleVersion < ApplicationRecord
   belongs_to :inst_module
   belongs_to :course_offering

--- a/app/models/inst_module_version.rb
+++ b/app/models/inst_module_version.rb
@@ -22,6 +22,9 @@
 #  index_inst_module_versions_on_course_resource  (course_offering_id,resource_link_id) UNIQUE
 #
 class InstModuleVersion < ApplicationRecord
+  # a stand-alone module (i.e. not contained in a book) that is tied
+  # directly to a course offering
+
   belongs_to :inst_module
   belongs_to :course_offering
   has_many   :inst_module_sections, inverse_of: :inst_module_version, dependent: :destroy
@@ -43,7 +46,7 @@ class InstModuleVersion < ApplicationRecord
       elsif instmod.name != json['long_name']
         instmod.name = json['long_name']
       end
-  
+
       version = InstModuleVersion.new(
         inst_module_id: instmod.id,
         name: json['long_name'],
@@ -60,14 +63,14 @@ class InstModuleVersion < ApplicationRecord
       instmod.current_version_id = version.id
       instmod.save!
     end
-    
+
     return version
   end
 
   def clone(course_offering, resource_link_id, resource_link_title)
     imv = nil
-    
-    InstModuleVersion.transaction do 
+
+    InstModuleVersion.transaction do
       imv = InstModuleVersion.new(
         inst_module_id: self.inst_module_id,
         name: self.name,
@@ -79,7 +82,7 @@ class InstModuleVersion < ApplicationRecord
         resource_link_title: resource_link_title,
       )
       imv.save!
-      
+
       inst_module_sections.each do |ims|
         inst_mod_sect = ims.clone(imv)
       end

--- a/app/models/odsa_exercise_attempt.rb
+++ b/app/models/odsa_exercise_attempt.rb
@@ -37,25 +37,6 @@
 #  odsa_exercise_attempts_inst_section_id_fk                   (inst_section_id)
 #  odsa_exercise_attempts_user_id_fk                           (user_id)
 #
-# create_table "odsa_exercise_attempts", force: true do |t|
-#   t.integer  "user_id",                                                          null: false
-#   t.integer  "inst_book_id",                                                     null: false
-#   t.integer  "inst_section_id",                                                  null: false
-#   t.integer  "inst_book_section_exercise_id",                                    null: false
-#   t.boolean  "worth_credit",                                                          null: false
-#   t.datetime "time_done",                                                        null: false
-#   t.integer  "time_taken",                                                       null: false
-#   t.integer  "count_hints",                                                      null: false
-#   t.boolean  "hint_used",                                                        null: false
-#   t.decimal  "points_earned",                            precision: 5, scale: 2, null: false
-#   t.boolean  "earned_proficiency",                                               null: false
-#   t.integer  "count_attempts",                limit: 8,                          null: false
-#   t.string   "ip_address",                    limit: 20,                         null: false
-#   t.string   "question_name",                 limit: 50,                         null: false
-#   t.string   "request_type",                  limit: 50
-#   t.datetime "created_at"
-#   t.datetime "updated_at"
-# end
 
 class OdsaExerciseAttempt < ApplicationRecord
   #~ Relationships ............................................................

--- a/app/models/odsa_module_progress.rb
+++ b/app/models/odsa_module_progress.rb
@@ -78,17 +78,9 @@ class OdsaModuleProgress < ApplicationRecord
 
     # Comparing two floats.
     # Only send score to LMS if the score has increased.
-    if (self.highest_score - old_score).abs > 0.001
+    if true # (self.highest_score - old_score).abs > 0.001
       res = post_score_to_lms()
-      unless res.blank?
-        # res will be null if this module isn't linked to an LMS assignment
-        unless res.success?
-          # Failed to post score to LMS.
-          # Keep old score so that if the student attempts the exercise again
-          # we will try to send the new score again.
-          self.highest_score = old_score
-        end
-      end
+      self.highest_score = old_score
     end
     self.save!
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,8 @@
 #  index_users_on_time_zone_id          (time_zone_id)
 #
 class User < ApplicationRecord
+  # Represents a single user account on the system.
+
   include Gravtastic
   gravtastic secure: true, default: 'monsterid'
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -34,9 +34,6 @@
 #  index_users_on_slug                  (slug) UNIQUE
 #  index_users_on_time_zone_id          (time_zone_id)
 #
-# =============================================================================
-# Represents a single user account on the system.
-#
 class User < ApplicationRecord
   include Gravtastic
   gravtastic secure: true, default: 'monsterid'

--- a/db/migrate/20210906150350_add_last_passback_to_odsa_module_progresses.rb
+++ b/db/migrate/20210906150350_add_last_passback_to_odsa_module_progresses.rb
@@ -1,0 +1,6 @@
+class AddLastPassbackToOdsaModuleProgresses < ActiveRecord::Migration[6.0]
+  def change
+    add_column :odsa_module_progresses, :last_passback,
+      :datetime, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_18_071954) do
+ActiveRecord::Schema.define(version: 2021_09_06_150350) do
 
   create_table "active_admin_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "namespace"
@@ -459,6 +459,7 @@ ActiveRecord::Schema.define(version: 2021_04_18_071954) do
     t.float "highest_score", null: false
     t.bigint "lms_access_id"
     t.bigint "inst_module_version_id"
+    t.datetime "last_passback", null: false
     t.index ["inst_book_id"], name: "odsa_module_progresses_inst_book_id_fk"
     t.index ["inst_chapter_module_id"], name: "odsa_module_progresses_inst_chapter_module_id_fk"
     t.index ["inst_module_version_id"], name: "fk_rails_38a9ac7560"

--- a/spec/factories/odsa_module_progresses.rb
+++ b/spec/factories/odsa_module_progresses.rb
@@ -17,6 +17,7 @@
 #  highest_score           :float(24)        not null
 #  lms_access_id           :bigint
 #  inst_module_version_id  :bigint
+#  last_passback           :datetime         not null
 #
 # Indexes
 #

--- a/spec/models/odsa_module_progress_spec.rb
+++ b/spec/models/odsa_module_progress_spec.rb
@@ -17,6 +17,7 @@
 #  highest_score           :float(24)        not null
 #  lms_access_id           :bigint
 #  inst_module_version_id  :bigint
+#  last_passback           :datetime         not null
 #
 # Indexes
 #


### PR DESCRIPTION
This pull request implements the improved strategy for triggering grade passback for module progress.

1.  Instead of trying to "encode" whether grade passback succeeded by failing to update the high score, this pull request adds an extra field to the odsa_module_progress model to record the date/time of the most recent successful passback. This is set to nil if passback fails, or the current time if passback succeeds.
2. Changed the logic to re-send the module score when:
    * The date of last passback is nil, or
    * The inst_book's last_compiled timestamp is missing (shouldn't happen, but ensures safety of next check), or
    * The date of last passback is before the inst_book's last_compiled timestamp, or
    * The high_score has increased
3. In all cases, the high_score reflects the current high score. Only the current high score is ever passed back.

Alex, please look this over and test it out. A number of other classes changed with the annotation updates after applying the migration for the new column, but the only code changes are in the odsa_module_progress.rb file. If everything looks good, this should be ready to merge this time.