### PR TITLE
fixed bug in InstCourseOfferingExercise#find_or_create_resource

### DIFF
--- a/app/models/inst_course_offering_exercise.rb
+++ b/app/models/inst_course_offering_exercise.rb
@@ -50,7 +50,7 @@ class InstCourseOfferingExercise < ApplicationRecord
         points = settings.delete('points') || 1
         threshold = settings.delete('threshold')
         unless threshold
-          threshold = ex.ex_type == 'ka' ? 5 : 1  
+          threshold = ex.ex_type == 'ka' ? 5 : 1
         end
         settings.delete('isGradable')
         settings.delete('required')
@@ -65,8 +65,22 @@ class InstCourseOfferingExercise < ApplicationRecord
         points: points,
         options: optionsJson,
       )
-      course_off_ex.save!
+    elsif settings
+      # Update values if settings hash is provided
+      points = settings.delete('points') || 1
+      threshold = settings.delete('threshold')
+      unless threshold
+        threshold = ex.ex_type == 'ka' ? 5 : 1
+      end
+      settings.delete('isGradable')
+      settings.delete('required')
+      optionsJson = settings.to_json
+
+      course_off_ex.points = points
+      course_off_ex.threshold = threshold
+      course_off_ex.options = optionsJson
     end
+    course_off_ex.save!
     return course_off_ex
   end
 
@@ -109,10 +123,10 @@ class InstCourseOfferingExercise < ApplicationRecord
   def self.handle_grade_passback(req, res, user_id, inst_course_offering_exercise_id)
     ex_progress = OdsaExerciseProgress.find_by(user_id: user_id,
       inst_course_offering_exercise_id: inst_course_offering_exercise_id)
-    
+
     if req.replace_request?
       # set a new score for the user
-            
+
       score = Float(req.score.to_s)
 
       if score < 0.0 || score > 1.0
@@ -143,7 +157,7 @@ class InstCourseOfferingExercise < ApplicationRecord
       res.score = ex_progress.blank? ? 0 : ex_progress.highest_score
       res.code_major = 'success'
     end
-    
+
     return res
   end
 


### PR DESCRIPTION
In InstCourseOfferingExercise, there are two closely-named (apparently closely related) methods: find_or_create and find_or_create_resource. Both methods take parameters and look up an existing object, creating a new one if no object is found.

The find_or_create method also _updates_ the retrieved object, if an existing object is found, which makes sense. However, the find_or_create_resource method in contrast _never_ updates the specified object if settings have changed, and only records settings on initial creation of the object. This leads to situations where the settings may have changed, but whether or not those new settings values are stored depends on which of the two methods are used.

This pull request fixes find_or_create_resource so that the settings updates are applied the same way between newly created or existing retrieved objects.

Actually, I'm unsure where these two methods are used, since the statements that extract the relevant settings for storage in the instance are actually different between the two methods. It would be better to refactor the code so there's only one method here, and it used the same logic consistently. Having two closely related, highly inter-duplicated but not identical methods is a maintenance risk. Also, this pull request is a partial response to fixing a bug arising from this duplication. But I'd rather have some additional eyes on the change to make sure it won't have unintended consequences before making a change that is larger.
