### PR TITLE
Be.treeviewfix

### DIFF
--- a/app/assets/javascripts/book_config.js
+++ b/app/assets/javascripts/book_config.js
@@ -800,6 +800,7 @@
       suppress_todo: $("#suppress-todo").is(":checked"),
       dispModComp: $("#disp-mod-comp").is(":checked"),
       zeropt_assignments: $("#zeropt-assignments").is(":checked"),
+      include_tree_view: $("#include_tree_view").is(":checked"),
       tabbed_codeinc: $("#tabbed-codeinc").is(":checked"),
       narration_enabled: $("#narration-enabled").is(":checked"),
       glob_exer_options: globalExerSettings(),
@@ -983,6 +984,9 @@
         case "zeropt_assignments":
           $("#zeropt-assignments").prop("checked", config.zeropt_assignments);
           break;
+        case "include_tree_view":
+          $("#include_tree_view").prop("checked", config.include_tree_view);
+          break;
         case "tabbed_codeinc":
           $("#tabbed-codeinc").prop("checked", config.tabbed_codeinc);
           break;
@@ -1063,6 +1067,9 @@
               break;
             case "zeropt_assignments":
               $("#zeropt-assignments").prop("checked", config.zeropt_assignments);
+              break;
+            case "include_tree_view":
+              $("#include_tree_view").prop("checked", config.include_tree_view);
               break;
             case "tabbed_codeinc":
               $("#tabbed-codeinc").prop("checked", config.tabbed_codeinc);

--- a/app/models/inst_book.rb
+++ b/app/models/inst_book.rb
@@ -63,6 +63,7 @@ class InstBook < ApplicationRecord
     options['assumes'] = book_data['assumes'] || "recursion"
     options['dispModComp'] = book_data['dispModComp'] || true
     options['zeropt_assignments'] = book_data['zeropt_assignments'] || false
+    options['include_tree_view'] = book_data['include_tree_view'] || false
     options['glob_exer_options'] = book_data['glob_exer_options'] || {}
 
     if inst_book_id == nil
@@ -234,6 +235,11 @@ class InstBook < ApplicationRecord
   def zeropt?
     zeropt = "\"zeropt_assignments\":true"
     return self.options.include? zeropt
+  end
+
+  def tree_view?
+    tree_view = "\"include_tree_view\":true"
+    return self.options.include? tree_view
   end
 
 end

--- a/app/views/configurations/book/show.html.haml
+++ b/app/views/configurations/book/show.html.haml
@@ -311,6 +311,10 @@
           %input{type: "checkbox", name: "zeropt-assignments", id: "zeropt-assignments"}
           %label{for: "zeropt-assignments"}
             Zero point assignments
+        .col-sm-6
+          %input{type: "checkbox", name: "include_tree_view", id: "include_tree_view"}
+          %label{for: "include_tree_view"}
+            Include TreeView
 
     %div{id: "book-content-container"}
       %h2

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_18_071954) do
+ActiveRecord::Schema.define(version: 2021_11_03_065052) do
 
   create_table "active_admin_comments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "namespace"
@@ -407,6 +407,7 @@ ActiveRecord::Schema.define(version: 2021_04_18_071954) do
     t.bigint "inst_module_section_exercise_id"
     t.string "answer"
     t.integer "question_id"
+    t.boolean "finished_frame"
     t.index ["inst_book_id"], name: "odsa_exercise_attempts_inst_book_id_fk"
     t.index ["inst_book_section_exercise_id"], name: "odsa_exercise_attempts_inst_book_section_exercise_id_fk"
     t.index ["inst_course_offering_exercise_id"], name: "odsa_exercise_attempts_inst_course_offering_exercise_id_fk"


### PR DESCRIPTION
Merges Be.treeviewfix->Master

Added an optional configuration flag called "include_tree_view" to both the LTI configurator and the book generator. When set 'true', the TreeView feature files are included in the book building, otherwise, they are not included. The default is 'false', which is also the assumed value if the "include_tree_view" flag is missing.