### PR TITLE
Fix staging Client 404s issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Jihane Najdi <jnajdi@vt.edu>
 # Default environment
 ARG RAILS_ENV='development'
 ARG ODSA_BRANCH='master'
-ARG LTI_BRANCH='master'
+ARG LTI_BRANCH='staging'
 
 ENV TZ=America/New_York
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone

--- a/app/controllers/lti13/login_initiations_controller.rb
+++ b/app/controllers/lti13/login_initiations_controller.rb
@@ -1,3 +1,8 @@
+require 'ostruct'
+# Note: (big fix for the 404 client error for LTI 1.3 login intiiations will be 
+# to update all @tool to @lms_instance in all LTI 1.3 haml/erb and controller files
+# Although the running the LTI 1.3 login intiations works well locally, but the 404s are on staging
+
 class Lti13::LoginInitiationsController < ApplicationController
   include Lti13::LoginInitiationsHelper
   skip_before_action only: :create
@@ -6,16 +11,25 @@ class Lti13::LoginInitiationsController < ApplicationController
 
   # OpenID allows for a GET or POST
 
-  # GET /lti/login_initiations
-  def index; end
+  # GET /lti13/login_initiations
+  def index
+    Rails.logger.debug('[LTI13::LoginInitiations#index] rendering index')
+    # The index view expects an object called @tool. 
+    # we already have an @lms_instance (populated from the session)
+    # and @tool is an abstraction that has not been set yet, create the view-friendly wrapper.
+    unless defined?(@tool) && @tool
+      @tool = present_as_tool(@lms_instance) if @lms_instance
+      Rails.logger.info "[LoginInitiations#index] built @tool: #{@tool.inspect}"
+    end
+  end
 
-  # POST /lti/login_initiations
+  # POST /lti13/login_initiations
   def create
     auth_url = build_auth_url(@lms_instance, @state_jwt, {
       login_hint: params[:login_hint], 
       lti_message_hint: params[:lti_message_hint]
     }, @nonce)  
-    Rails.logger.info "LoginInitiationsController#create: Redirecting to #{auth_url}"
+    Rails.logger.info "LoginInitiationsController#create: auth_url: #{auth_url}"
     redirect_to auth_url
   end
 
@@ -31,9 +45,33 @@ class Lti13::LoginInitiationsController < ApplicationController
     @lms_instance = LmsInstance.find_by(issuer: issuer, client_id: client_id)
 
     unless @lms_instance
+      Rails.logger.warn 'set_tool: LMS Instance NOT found'
       render json: { error: 'LMS Instance not found or configuration mismatch' }, status: :not_found
       return
     end
+    # Build @tool alias for views that still use @tool
+    # Remove/comment this line out after big fix
+    @tool = present_as_tool(@lms_instance)
+    Rails.logger.debug "[set_tool] @tool proxy: #{@tool.inspect}"
+
+    # Store LTI1.3 params in session so we can use this for subsequent requests to index 
+    # so the next GET for /lti13/login_initiations index can easily access the @lms_instance
+    session[:lms_instance_id] = @lms_instance.id
+    session[:issuer]          = @lms_instance.issuer
+    session[:client_id]       = @lms_instance.client_id
+  end
+
+  # Helper to makes this struct available to the view layer 
+  # Remove/comment this method out after big fix
+  def present_as_tool(lms)
+    OpenStruct.new(
+      id:                       lms.id,
+      name:                     (lms.respond_to?(:name) && lms.name.present?) ? lms.name : (lms.url || lms.issuer),
+      client_id:                lms.client_id,
+      issuer:                   lms.issuer,
+      platform_oidc_auth_url:   lms.platform_oidc_auth_url,
+      oauth2_url:               lms.oauth2_url
+    )
   end
 
   def generate_state_jwt


### PR DESCRIPTION
Fix LTI 1.3 404s: wrap LmsInstance in OpenStruct as @tool for legacy views